### PR TITLE
Resolving console errors

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "electron-squirrel-startup": "^1.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-google-charts": "^4.0.1",
         "react-router-dom": "^6.17.0"
       },
       "devDependencies": {
@@ -14311,6 +14312,15 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-google-charts": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-4.0.1.tgz",
+      "integrity": "sha512-V/hcMcNuBgD5w49BYTUDye+bUKaPmsU5vy/9W/Nj2xEeGn+6/AuH9IvBkbDcNBsY00cV9OeexdmgfI5RFHgsXQ==",
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -27961,6 +27971,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-google-charts": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-4.0.1.tgz",
+      "integrity": "sha512-V/hcMcNuBgD5w49BYTUDye+bUKaPmsU5vy/9W/Nj2xEeGn+6/AuH9IvBkbDcNBsY00cV9OeexdmgfI5RFHgsXQ==",
+      "requires": {}
     },
     "react-is": {
       "version": "18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,6 +69,7 @@
     "electron-squirrel-startup": "^1.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-google-charts": "^4.0.1",
     "react-router-dom": "^6.17.0"
   },
   "proxy": "http://localhost:8000"

--- a/frontend/src/components/DashboardItems/DashboardItem5.jsx
+++ b/frontend/src/components/DashboardItems/DashboardItem5.jsx
@@ -1,23 +1,21 @@
 import { Box } from "@mui/material";
 import React from "react";
-import { PieChart } from '@mui/x-charts/PieChart';
+import { Chart } from 'react-google-charts';
 
 function DashboardItem5({ roles }) {
 
     // FUTURE IMPLEMENTATION: have backend include is_former_employee data so employees who are former employee will not be included in pie chart
-    const data = roles.map((role, idx) => ({
-        id: idx,
-        value: role.employees.length,
-        label: role.role
-    }));
+    const data = roles.map(role => [role.role, role.employees.length]);
+    data.unshift(["Employee Role", "Number of Employees"]);
+
+    const options = {
+        title: "Employees for Each Role"
+    }
 
     return (
         <Box
             sx={{
-                // bgcolor: theme.palette.tertiary.main,
-                // boxShadow: 1,
                 p: 8,
-                // minWidth: 300,
             }}
         >
             <Box sx={{ 
@@ -26,18 +24,16 @@ function DashboardItem5({ roles }) {
                 fontWeight: 'bold',
                 mx: 0.5,
                 fontSize: 24,
-                }}>Employees for Each Role</Box>
-            <PieChart 
-                series={[
-                    {
-                      data,
-                      cx: 150
-                    },
-                  ]}
-                  width={850}
-                  height={150}
-                 
-            /> 
+                }}
+            >
+                Employees for Each Role
+            </Box>
+            <Chart 
+                chartType="PieChart"
+                data={data}
+                width={"850px"}
+                height={"250px"}
+            />
         </Box>)
 }
 


### PR DESCRIPTION
Switch pie chart element from material ui's PieChart element to google chart.

New pie chart no longer displays errors on the console and has built in pages for when role overflow on the legend

![Screenshot 2023-11-15 144918](https://github.com/aA-Hackathon-Team-9/hackathon_team9/assets/109548330/a991611a-4573-4c6a-864c-d668a4b67f39)
